### PR TITLE
Remove log internal calls from stack

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -74,7 +74,8 @@ func (h *ZerologHandler) Handle(ctx context.Context, record slog.Record) error {
 
 	event := h.option.Logger.
 		WithLevel(level).
-		Ctx(ctx)
+		Ctx(ctx).
+		CallerSkipFrame(3)
 
 	if !h.option.NoTimestamp {
 		event.Time(zerolog.TimestampFieldName, record.Time)


### PR DESCRIPTION
Hello,

i'm using `Stack()` on my zerolog context. For everything logged via `slog`, the file and line doesn't make sense. So I think we should skip the 3 calls in the call stack added by this middleware.
